### PR TITLE
Remove statistics banner from resources-standalone.html

### DIFF
--- a/resources-standalone.html
+++ b/resources-standalone.html
@@ -70,40 +70,7 @@
       font-weight: 400;
     }
     
-    /* Refined Stats Banner */
-    .stats-banner {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 20px;
-      margin: 20px 0 0;
-      padding: 18px 24px;
-      background: var(--chip);
-      border: 1px solid var(--line);
-      border-radius: var(--radius);
-      box-shadow: var(--shadow-light);
-    }
-    
-    .stat-item {
-      text-align: center;
-      flex: 1;
-    }
-    
-    .stat-number {
-      font-size: 24px;
-      font-weight: 700;
-      color: var(--accent);
-      margin-bottom: 2px;
-      line-height: 1;
-    }
-    
-    .stat-label {
-      font-size: 11px;
-      color: var(--muted);
-      font-weight: 500;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
+
     .toolbar{ 
       margin: 32px 0 0; 
       display: flex; 
@@ -447,25 +414,7 @@
     <h1>Japan MR Resource Central</h1>
     <p class="lead">Fast, credible primers for conducting healthcare market research in Japan. Skimmable summaries, direct PDF downloads.</p>
     
-    <!-- Resource Statistics -->
-    <div class="stats-banner">
-      <div class="stat-item">
-        <div class="stat-number">9</div>
-        <div class="stat-label">Guides</div>
-      </div>
-      <div class="stat-item">
-        <div class="stat-number">68+</div>
-        <div class="stat-label">FAQ</div>
-      </div>
-      <div class="stat-item">
-        <div class="stat-number">7</div>
-        <div class="stat-label">Categories</div>
-      </div>
-      <div class="stat-item">
-        <div class="stat-number">PDF</div>
-        <div class="stat-label">Ready</div>
-      </div>
-    </div>
+
     
     <!-- What would you like to know? Section -->
     <div class="guide-section" id="guide">


### PR DESCRIPTION
- Removed stats-banner section (9 Guides, 68+ FAQ, 7 Categories, PDF Ready)
- Removed related CSS styles for stats-banner, stat-item, stat-number, stat-label
- 'What would you like to know?' section now appears directly below 'Japan MR Resource Central'