### PR TITLE
新規案件追加: ATTR-CM アミロイドーシス

### DIFF
--- a/project-tracker/seed_planning_data.csv
+++ b/project-tracker/seed_planning_data.csv
@@ -422,3 +422,4 @@ IgA腎症,"IgA nephropathy, IgAN",IDI,定性,患者,,1,IgA腎症の診断確定�
 慢性閉塞性肺疾患,COPD,IDI,定性,介護者,,3,"40～85歳で慢性閉塞性肺疾患(COPD)、慢性気管支炎、肺気腫と診断され、現在治療薬を使用/服用している患者	または、患者を介護している18歳以上の介護者																	",,3Hメディソリューションズ,Fieldcats
 TEST,,TEST,TEST,医師,,1,,,,
 ATTRアミロイドーシス,"ATTR, ATTR-CM",IDI,定性,医師,神経内科,7,過去12ヵ月で3人以上のATTR-CMまたはhATTR-PN の患者を診ていること,,キャンドゥ,MarketVision
+ATTR-CM アミロイドーシス,"ATTR, ATTR-CM",IDI,定性,医師,循環器科,7,過去12ヵ月で3人以上のATTR-CMまたはhATTR-PNの患者を診ていること,,キャンドゥ,MarketVision


### PR DESCRIPTION
## 新規案件追加

### 案件情報
- **疾患名:** ATTR-CM アミロイドーシス
- **疾患略語:** ATTR, ATTR-CM
- **手法:** IDI
- **調査種別:** 定性
- **対象者種別:** 医師
- **専門:** 循環器科
- **実績数:** 7名
- **対象条件:** 過去12ヵ月で3人以上のATTR-CMまたはhATTR-PNの患者を診ていること
- **薬剤:** -
- **リクルート実施:** キャンドゥ
- **クライアント:** MarketVision


**登録者:** 本田　良英

**登録日時:** 2025-10-20T07:05:55.898Z

---
このPRは自動生成されました。内容を確認してマージしてください。
