### PR TITLE
Extend dark theme across project tracker pages

### DIFF
--- a/project-tracker/css/style-2026.css
+++ b/project-tracker/css/style-2026.css
@@ -420,7 +420,7 @@ nav .active-page {
 /* ================================================================
    Dashboard 2026 refresh — preserve content, improve hierarchy
    ================================================================ */
-.dashboard-page {
+.app-page {
   --dashboard-bg: #07111f;
   --dashboard-panel: rgba(15, 31, 50, 0.9);
   --dashboard-panel-strong: #10243a;
@@ -437,7 +437,7 @@ nav .active-page {
     var(--dashboard-bg) !important;
 }
 
-.dashboard-page nav {
+.app-page nav {
   background-color: rgba(7, 17, 31, 0.92) !important;
   background-image: linear-gradient(90deg, rgba(7, 17, 31, .96), rgba(12, 31, 50, .9)) !important;
   border-bottom: 1px solid var(--dashboard-border);
@@ -445,14 +445,14 @@ nav .active-page {
   backdrop-filter: blur(18px);
 }
 
-.dashboard-page nav h1 { color: var(--dashboard-text) !important; }
-.dashboard-page nav a { border: 1px solid var(--dashboard-border); }
-.dashboard-page nav a.bg-gray-100 {
+.app-page nav h1 { color: var(--dashboard-text) !important; }
+.app-page nav a { border: 1px solid var(--dashboard-border); }
+.app-page nav a.bg-gray-100 {
   color: #c5d6e2 !important;
   background: rgba(255, 255, 255, 0.045) !important;
 }
-.dashboard-page nav a.bg-gray-100:hover { background: rgba(32, 213, 210, 0.1) !important; }
-.dashboard-page nav .bg-sp-primary {
+.app-page nav a.bg-gray-100:hover { background: rgba(32, 213, 210, 0.1) !important; }
+.app-page nav .bg-sp-primary {
   color: #031317 !important;
   background: linear-gradient(135deg, var(--dashboard-accent), #6ee7f0) !important;
   box-shadow: 0 0 24px rgba(32, 213, 210, 0.2);
@@ -512,40 +512,92 @@ nav .active-page {
 .connection-retry { color: var(--dashboard-accent); font-weight: 700; padding-left: .35rem; }
 .connection-retry:disabled { opacity: .5; }
 
-.dashboard-page .container > .grid > div,
-.dashboard-page .container > .bg-white {
+.app-page .container > .grid > div,
+.app-page .container > .bg-white,
+.app-page main .bg-white {
   color: var(--dashboard-text);
   border: 1px solid var(--dashboard-border);
   background: var(--dashboard-panel) !important;
   box-shadow: 0 18px 46px rgba(0, 0, 0, .22) !important;
   backdrop-filter: blur(12px);
 }
-.dashboard-page .container > .grid:first-of-type > div {
+.app-page .rounded-lg.shadow-md,
+.app-page .bg-white.rounded-xl.shadow-2xl,
+.app-page .bg-white.rounded-2xl.shadow-2xl,
+.app-page .search-container {
+  color: var(--dashboard-text);
+  border: 1px solid var(--dashboard-border) !important;
+  background-color: var(--dashboard-panel) !important;
+  background-image: linear-gradient(135deg, rgba(18, 45, 69, .94), rgba(9, 24, 40, .94)) !important;
+  box-shadow: 0 18px 46px rgba(0, 0, 0, .22) !important;
+  backdrop-filter: blur(12px);
+}
+.app-page .rounded-lg.shadow-md .border-gray-200,
+.app-page .rounded-lg.shadow-md .border-gray-300 { border-color: var(--dashboard-border) !important; }
+.app-page .container > .grid:first-of-type > div {
   position: relative;
   overflow: hidden;
   border-radius: 1.1rem;
 }
-.dashboard-page .container > .grid:first-of-type > div::before {
+.app-page .container > .grid:first-of-type > div::before {
   content: '';
   position: absolute;
   inset: 0 auto 0 0;
   width: 3px;
   background: linear-gradient(var(--dashboard-accent), var(--dashboard-accent-2));
 }
-.dashboard-page .text-gray-500 { color: var(--dashboard-muted) !important; }
-.dashboard-page .bg-gray-50 { background: rgba(255, 255, 255, .035) !important; }
-.dashboard-page tbody.bg-white { background: transparent !important; }
-.dashboard-page tbody tr { border-color: var(--dashboard-border) !important; transition: background .2s ease; }
-.dashboard-page tbody tr:hover { background: rgba(32, 213, 210, .055); }
-.dashboard-page th { color: #7f9cb0 !important; letter-spacing: .08em; }
-.dashboard-page td { color: #d5e3ec; }
-.dashboard-page h2 { color: var(--dashboard-text); }
-.dashboard-page button.bg-gray-100 {
+.app-page .text-gray-500,
+.app-page .text-gray-600 { color: var(--dashboard-muted) !important; }
+.app-page .text-gray-700,
+.app-page .text-gray-800,
+.app-page .text-gray-900 { color: var(--dashboard-text) !important; }
+.app-page .bg-gray-50 { background: rgba(255, 255, 255, .035) !important; }
+.app-page tbody.bg-white { background: transparent !important; }
+.app-page tbody tr { border-color: var(--dashboard-border) !important; transition: background .2s ease; }
+.app-page tbody tr:hover { background: rgba(32, 213, 210, .055); }
+.app-page th { color: #7f9cb0 !important; letter-spacing: .08em; }
+.app-page td { color: #d5e3ec; }
+.app-page h2,
+.app-page h3 { color: var(--dashboard-text); }
+.app-page button.bg-gray-100 {
   color: #bcd0dd !important;
   background: rgba(255, 255, 255, .06) !important;
   border: 1px solid var(--dashboard-border);
 }
-.dashboard-page .mt-8 > a { border: 1px solid rgba(255, 255, 255, .12); box-shadow: 0 10px 28px rgba(0, 0, 0, .2); }
+.app-page .mt-8 > a { border: 1px solid rgba(255, 255, 255, .12); box-shadow: 0 10px 28px rgba(0, 0, 0, .2); }
+
+.app-page input[type="text"],
+.app-page input[type="email"],
+.app-page input[type="password"],
+.app-page input[type="number"],
+.app-page input[type="date"],
+.app-page input[type="search"],
+.app-page select,
+.app-page textarea {
+  color: var(--dashboard-text) !important;
+  background: rgba(5, 17, 31, .72) !important;
+  border-color: var(--dashboard-border) !important;
+}
+.app-page input:focus,
+.app-page select:focus,
+.app-page textarea:focus {
+  color: var(--dashboard-text) !important;
+  background: rgba(9, 25, 42, .96) !important;
+  border-color: var(--dashboard-accent) !important;
+  box-shadow: 0 0 0 4px rgba(32, 213, 210, .1) !important;
+}
+.app-page label { color: #c8d8e3; }
+.app-page option { color: #102033; background: #fff; }
+.app-page .link-card[class*="from-"] {
+  color: var(--dashboard-text) !important;
+  background-color: rgba(21, 43, 65, .9) !important;
+  background-image: linear-gradient(135deg, rgba(31, 66, 91, .92), rgba(15, 35, 55, .96)) !important;
+  border-color: var(--dashboard-border) !important;
+}
+.app-page .link-card[class*="from-"]:hover {
+  background-image: linear-gradient(135deg, rgba(35, 89, 111, .96), rgba(17, 48, 69, .98)) !important;
+  border-color: rgba(32, 213, 210, .35) !important;
+}
 
 @media (max-width: 767px) {
   .dashboard-hero { align-items: flex-start; flex-direction: column; padding: 1.4rem; }

--- a/project-tracker/css/style-2026.css
+++ b/project-tracker/css/style-2026.css
@@ -604,3 +604,8 @@ nav .active-page {
   .connection-status { min-width: 0; width: 100%; flex-wrap: wrap; border-radius: 1rem; }
   .dashboard-page .container { padding-left: .85rem; padding-right: .85rem; }
 }
+
+.app-page .bg-yellow-50 p,
+.app-page .bg-blue-50 p {
+  color: #1f2937 !important;
+}

--- a/project-tracker/index.html
+++ b/project-tracker/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/png" href="SP_logo_shape_only.png">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css?v=20260805-2">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
   <link rel="stylesheet" href="css/components.css">
   
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -19,15 +19,14 @@
   <script src="js/utils.js"></script>
   <script src="js/data/specialties-master.js"></script>
 </head>
-<body class="dashboard-page bg-gray-50">
+<body class="app-page dashboard-page bg-gray-50">
   <!-- ナビゲーション -->
   <nav class="bg-white shadow-md sticky top-0 z-40">
     <div class="container mx-auto px-2 sm:px-4 py-2 sm:py-3">
       <div class="flex items-center justify-between flex-wrap gap-2">
         <!-- ロゴ部分 -->
         <div class="flex items-center space-x-2 sm:space-x-4">
-          <img src="Seed_Planning_Logo_Original.jpg" alt="SEED PLANNING" class="h-8 sm:h-10">
-          <h1 class="hidden md:block text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
+          <h1 class="text-sm sm:text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
         </div>
         
         <!-- ナビゲーションボタン -->

--- a/project-tracker/index.html
+++ b/project-tracker/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/png" href="SP_logo_shape_only.png">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-6">
   <link rel="stylesheet" href="css/components.css">
   
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/project-tracker/links.html
+++ b/project-tracker/links.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/png" href="SP_logo_shape_only.png">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   
@@ -67,15 +67,14 @@
 
   </style>
 </head>
-<body class="bg-gray-50">
+<body class="app-page bg-gray-50">
   <!-- ナビゲーション -->
   <nav class="bg-white shadow-md sticky top-0 z-40">
     <div class="container mx-auto px-2 sm:px-4 py-2 sm:py-3">
       <div class="flex items-center justify-between flex-wrap gap-2">
         <!-- ロゴ部分 -->
         <div class="flex items-center space-x-2 sm:space-x-4">
-          <img src="Seed_Planning_Logo_Original.jpg" alt="SEED PLANNING" class="h-8 sm:h-10">
-          <h1 class="hidden md:block text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
+          <h1 class="text-sm sm:text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
         </div>
         
         <!-- ナビゲーションボタン -->

--- a/project-tracker/links.html
+++ b/project-tracker/links.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/png" href="SP_logo_shape_only.png">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-6">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   

--- a/project-tracker/projects.html
+++ b/project-tracker/projects.html
@@ -42,7 +42,7 @@
   
   
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   
@@ -254,15 +254,14 @@
     }
   </style>
 </head>
-<body class="bg-gray-50">
+<body class="app-page bg-gray-50">
   <!-- ナビゲーション -->
   <nav class="bg-white shadow-md sticky top-0 z-40">
     <div class="container mx-auto px-2 sm:px-4 py-2 sm:py-3">
       <div class="flex items-center justify-between flex-wrap gap-2">
         <!-- ロゴ部分 -->
         <div class="flex items-center space-x-2 sm:space-x-4">
-          <img src="Seed_Planning_Logo_Original.jpg" alt="SEED PLANNING" class="h-8 sm:h-10">
-          <h1 class="hidden md:block text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
+          <h1 class="text-sm sm:text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
         </div>
         
         <!-- ナビゲーションボタン -->

--- a/project-tracker/projects.html
+++ b/project-tracker/projects.html
@@ -42,7 +42,7 @@
   
   
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-6">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   

--- a/project-tracker/register.html
+++ b/project-tracker/register.html
@@ -11,7 +11,7 @@
   <meta http-equiv="Expires" content="0">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   
@@ -21,15 +21,14 @@
   <script src="js/config.js"></script>
   <script src="js/database.js"></script>
 </head>
-<body class="bg-gray-50">
+<body class="app-page bg-gray-50">
   <!-- ナビゲーション -->
   <nav class="bg-white shadow-md sticky top-0 z-40">
     <div class="container mx-auto px-2 sm:px-4 py-2 sm:py-3">
       <div class="flex items-center justify-between flex-wrap gap-2">
         <!-- ロゴ部分 -->
         <div class="flex items-center space-x-2 sm:space-x-4">
-          <img src="Seed_Planning_Logo_Original.jpg" alt="SEED PLANNING" class="h-8 sm:h-10">
-          <h1 class="hidden md:block text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
+          <h1 class="text-sm sm:text-lg font-bold text-gray-800">プロジェクト履歴管理システム</h1>
         </div>
         
         <!-- ナビゲーションボタン -->

--- a/project-tracker/register.html
+++ b/project-tracker/register.html
@@ -11,7 +11,7 @@
   <meta http-equiv="Expires" content="0">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css?v=20260805-5">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-6">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   


### PR DESCRIPTION
## 概要
PR #441で導入したダークダッシュボードのデザインを、新規登録・案件検索・リンク集にも展開し、4ページ共通のヘッダーからSeed Planningロゴ画像を撤去します。

## 変更内容
- 4ページに共通の `app-page` テーマを適用
- 新規登録フォーム、案件検索パネル・結果カード、リンク集セクションをダークテーマ化
- 入力欄、ラベル、フォーカス状態、リンクカードのコントラストを調整
- 4ページのSeed Planningロゴ画像を削除
- ロゴ撤去後もシステム名をモバイルで表示
- CSSキャッシュバージョンを更新

## 検証
- 4ページすべてでロゴ参照0件
- 各ページのナビゲーション6件を維持
- 新規登録フォーム20入力要素を維持
- 案件検索の675件表示を確認
- リンク集カードを目視確認
- 横方向のオーバーフローなし
- Git差分チェック