### PR TITLE
Fix project detail modal text contrast

### DIFF
--- a/project-tracker/css/style-2026.css
+++ b/project-tracker/css/style-2026.css
@@ -609,3 +609,10 @@ nav .active-page {
 .app-page .bg-blue-50 p {
   color: #1f2937 !important;
 }
+
+.app-page #similarProjectsList .text-gray-900,
+.app-page #similarProjectsList .text-gray-600,
+.app-page #similarProjectsList span.font-medium:not(.text-red-600):not(.text-green-600),
+.app-page #detailModal button.bg-gray-200 {
+  color: #1f2937 !important;
+}

--- a/project-tracker/projects.html
+++ b/project-tracker/projects.html
@@ -42,7 +42,7 @@
   
   
   <!-- Project Tracker スタイルシート -->
-  <link rel="stylesheet" href="css/style-2026.css?v=20260805-6">
+  <link rel="stylesheet" href="css/style-2026.css?v=20260805-7">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   


### PR DESCRIPTION
## 概要
案件検索ページの詳細ポップアップで、類似案件カード内の文字と「閉じる」ボタンが淡い背景に埋もれていた問題を修正します。

## 変更内容
- 類似案件の病名・略称・対象者・専門などを濃い黒字へ変更
- 「閉じる」ボタンの文字を濃い黒字へ変更
- CSSキャッシュバージョンを更新

## 検証
- 詳細ポップアップを実際に開いて表示確認
- 対象文字と「閉じる」の計算後カラーが `rgb(31, 41, 55)` であることを確認